### PR TITLE
Alternative type_checked implementation that allows for arguments.

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -11,12 +11,12 @@ import unittest
 from uniphy import decorators
 
 
-@decorators.type_checked()
+@decorators.type_checked
 def test_func1(a: int, b: "nonsene", c: 1*1 = "hello") -> (1, 'hala'):
     pass
 
 
-@decorators.type_checked()
+@decorators.type_checked
 def test_func2(a, b: str, c=None, d: list = None):
     pass
 
@@ -42,7 +42,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_return_correct():
         """Raise no exception when return type is correct."""
 
-        @decorators.type_checked()
+        @decorators.type_checked
         def a() -> int:
             return 1
 
@@ -51,7 +51,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_return_incorrect(self):
         """Raise Type when return type incorrect."""
 
-        @decorators.type_checked()
+        @decorators.type_checked
         def a() -> int:
             return "hello"
 
@@ -106,13 +106,13 @@ class TestTypeChecked(unittest.TestCase):
         def a(a: int = 2):
             pass
 
-        b = decorators.type_checked()(a)
+        b = decorators.type_checked(a)
         self.assertEqual(a.__annotations__, b.__annotations__)
 
     def test_wrong_default_arguments(self):
         """Test if wrong default arguments raise TypeError at function definition."""
         with self.assertRaises(TypeError):
-            @decorators.type_checked()
+            @decorators.type_checked
             def test_func(a: int = "hello"):
                 pass
 
@@ -120,7 +120,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_works_with_args_kwargs():
         """Test that *args and **kwargs are ignored."""
 
-        @decorators.type_checked()
+        @decorators.type_checked
         def test_func(*args: int, **kwargs: int):
             pass
 
@@ -130,7 +130,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test correct annotations for bound methods."""
 
         class CorrectAnnotation():
-            @decorators.type_checked()
+            @decorators.type_checked
             def bar(self, a: int):
                 pass
 
@@ -145,7 +145,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test bound method with wrong return value."""
 
         class WrongReturnValue():
-            @decorators.type_checked()
+            @decorators.type_checked
             def bar(self) -> int:
                 return "hello"
 
@@ -157,7 +157,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test bound methods with a wrong default value."""
         with self.assertRaises(TypeError):
             class WrongDefaultValue():
-                @decorators.type_checked()
+                @decorators.type_checked
                 def bar(self, a: int = "hello"):
                     pass
 
@@ -166,7 +166,7 @@ class TestTypeChecked(unittest.TestCase):
 
         class CorrectAnnotation():
             @classmethod
-            @decorators.type_checked()
+            @decorators.type_checked
             def bar(cls, a: int):
                 pass
 
@@ -181,7 +181,7 @@ class TestTypeChecked(unittest.TestCase):
 
         class WrongReturnValue():
             @classmethod
-            @decorators.type_checked()
+            @decorators.type_checked
             def bar(cls) -> int:
                 return "hello"
 
@@ -193,7 +193,7 @@ class TestTypeChecked(unittest.TestCase):
         with self.assertRaises(TypeError):
             class WrongDefaultValue():
                 @classmethod
-                @decorators.type_checked()
+                @decorators.type_checked
                 def bar(cls, a: int = "hello"):
                     pass
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -11,12 +11,12 @@ import unittest
 from uniphy import decorators
 
 
-@decorators.type_checked
+@decorators.type_checked()
 def test_func1(a: int, b: "nonsene", c: 1*1 = "hello") -> (1, 'hala'):
     pass
 
 
-@decorators.type_checked
+@decorators.type_checked()
 def test_func2(a, b: str, c=None, d: list = None):
     pass
 
@@ -42,7 +42,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_return_correct():
         """Raise no exception when return type is correct."""
 
-        @decorators.type_checked
+        @decorators.type_checked()
         def a() -> int:
             return 1
 
@@ -51,7 +51,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_return_incorrect(self):
         """Raise Type when return type incorrect."""
 
-        @decorators.type_checked
+        @decorators.type_checked()
         def a() -> int:
             return "hello"
 
@@ -106,13 +106,13 @@ class TestTypeChecked(unittest.TestCase):
         def a(a: int = 2):
             pass
 
-        b = decorators.type_checked(a)
+        b = decorators.type_checked()(a)
         self.assertEqual(a.__annotations__, b.__annotations__)
 
     def test_wrong_default_arguments(self):
         """Test if wrong default arguments raise TypeError at function definition."""
         with self.assertRaises(TypeError):
-            @decorators.type_checked
+            @decorators.type_checked()
             def test_func(a: int = "hello"):
                 pass
 
@@ -120,7 +120,7 @@ class TestTypeChecked(unittest.TestCase):
     def test_works_with_args_kwargs():
         """Test that *args and **kwargs are ignored."""
 
-        @decorators.type_checked
+        @decorators.type_checked()
         def test_func(*args: int, **kwargs: int):
             pass
 
@@ -130,7 +130,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test correct annotations for bound methods."""
 
         class CorrectAnnotation():
-            @decorators.type_checked
+            @decorators.type_checked()
             def bar(self, a: int):
                 pass
 
@@ -145,7 +145,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test bound method with wrong return value."""
 
         class WrongReturnValue():
-            @decorators.type_checked
+            @decorators.type_checked()
             def bar(self) -> int:
                 return "hello"
 
@@ -157,7 +157,7 @@ class TestTypeChecked(unittest.TestCase):
         """Test bound methods with a wrong default value."""
         with self.assertRaises(TypeError):
             class WrongDefaultValue():
-                @decorators.type_checked
+                @decorators.type_checked()
                 def bar(self, a: int = "hello"):
                     pass
 
@@ -166,7 +166,7 @@ class TestTypeChecked(unittest.TestCase):
 
         class CorrectAnnotation():
             @classmethod
-            @decorators.type_checked
+            @decorators.type_checked()
             def bar(cls, a: int):
                 pass
 
@@ -181,7 +181,7 @@ class TestTypeChecked(unittest.TestCase):
 
         class WrongReturnValue():
             @classmethod
-            @decorators.type_checked
+            @decorators.type_checked()
             def bar(cls) -> int:
                 return "hello"
 
@@ -193,7 +193,7 @@ class TestTypeChecked(unittest.TestCase):
         with self.assertRaises(TypeError):
             class WrongDefaultValue():
                 @classmethod
-                @decorators.type_checked
+                @decorators.type_checked()
                 def bar(cls, a: int = "hello"):
                     pass
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -37,7 +37,6 @@ failures2 = [
 
 
 class TestTypeChecked(unittest.TestCase):
-
     @staticmethod
     def test_return_correct():
         """Raise no exception when return type is correct."""
@@ -199,6 +198,86 @@ class TestTypeChecked(unittest.TestCase):
 
     # def test_static_method(self):
     #     # Not tested yet because in principle equivalent to normal function.
+
+    def test_decorator_arguments_no_arguments(self):
+        """Test whether @type_checked is the same as @type_checked()"""
+
+        def foo():
+            pass
+
+        # @type_checked
+        decorated_without_brackets = decorators.type_checked(foo)
+        # @type_checked()
+        decorated_with_brackets = decorators.type_checked()(foo)
+        # Test that same
+        self.assertEqual(decorated_without_brackets.__wrapped__, decorated_with_brackets.__wrapped__)
+
+    def test_decorator_arguments_positional_only(self):
+        """"Test whether positional arguments work for decorator"""
+
+        @decorators.type_checked(False, False, False)
+        def foo(a: int, b: int = 2.3) -> int:
+            return "hello"
+
+        # Check all functionality turned off.
+        foo(2.3)
+
+        # Check only some functionality turned off.
+        with self.assertRaises(TypeError):
+            decorators.type_checked(False, True, False)(foo)
+
+    def test_decorator_arguments_keyword_only(self):
+        """"Test whether keyword arguments work for decorator"""
+
+        @decorators.type_checked(check_arguments=False, check_defaults=False, check_return=False)
+        def foo(a: int, b: int = 2.3) -> int:
+            return "hello"
+
+        # Check all functionality turned off.
+        foo(2.3)
+
+        # Check only some functionality turned off.
+        with self.assertRaises(TypeError):
+            decorators.type_checked(check_arguments=False, check_defaults=True, check_return=False)(foo)
+
+    def test_decorator_arguements_positional_and_keyword(self):
+        """"Test whether positional and keyword arguments mixed work for decorator"""
+
+        @decorators.type_checked(False, check_defaults=False, check_return=False)
+        def foo(a: int, b: int = 2.3) -> int:
+            return "hello"
+
+        # Check all functionality turned off.
+        foo(2.3)
+
+        # Check only some functionality turned off.
+        with self.assertRaises(TypeError):
+            decorators.type_checked(False, check_defaults=True, check_return=False)(foo)
+
+    def test_decorator_arguments_wrong_arguments(self):
+        def foo():
+            pass
+
+        with self.assertRaises(TypeError):
+            decorators.type_checked(2)(foo)
+        with self.assertRaises(TypeError):
+            decorators.type_checked(check_arguments=2)
+
+    def test_decorating_class_method_raises_type_error(self):
+        @classmethod
+        def foo():
+            pass
+
+        with self.assertRaises(TypeError):
+            decorators.type_checked(foo)
+
+    def test_decorating_static_method_raises_type_error(self):
+        @staticmethod
+        def foo():
+            pass
+
+        with self.assertRaises(TypeError):
+            decorators.type_checked(foo)
 
 
 if __name__ == '__main__':

--- a/uniphy/__init__.py
+++ b/uniphy/__init__.py
@@ -1,2 +1,3 @@
 __author__ = "Jonas Eschle 'Mayou36', Johannes Lade, Jim Buffat"
 __version__ = '0.0.1'
+

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -47,7 +47,7 @@ class type_checked():
         Parameters
         ----------
         check_arguments : bool
-            Decided wheter arguments should be checked at execution time.
+            Decided whether arguments should be checked at execution time.
         check_defaults : bool
             Decides whether default values should be checked at declaration.
         check_return : bool
@@ -79,6 +79,7 @@ class type_checked():
                     and parameter.default is not None
                     and self.__is_suitable_annotation(parameter.annotation)
                     and not isinstance(parameter.default, parameter.annotation)):
+
                     msg = 'default argument {}={} is not instance of {}'
                     raise TypeError(msg.format(parameter.name, parameter.default,
                                                parameter.annotation))
@@ -96,6 +97,7 @@ class type_checked():
                     if (parameter.kind in self.ALLOWED_PARAMETER_KINDS
                         and self.__is_suitable_annotation(annotation)
                         and not isinstance(value, annotation)):
+
                         msg = 'argument {}={} is not instance of {}'
                         raise TypeError(msg.format(arg_name, value, annotation))
 

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -12,7 +12,6 @@ from inspect import Parameter
 
 
 class type_checked():
-
     """Decorator for dynamic type checking with annotations.
 
     + Each Parameter and the return value can be annotated with one expression of <class 'type'>.
@@ -46,7 +45,7 @@ class type_checked():
             raise TypeError("Illegal decorator arguments: args={}, kwargs={}".format(args, kwargs))
 
     def __init__(self, check_arguments=True, check_defaults=True, check_return=True):
-        """
+        """Initializes the decorator and sets the decorator arguments.
 
         Parameters
         ----------
@@ -62,7 +61,7 @@ class type_checked():
         self.check_return = check_return
 
     def __call__(self, func):
-        """
+        """Decorates the function.
 
         Parameters
         ----------
@@ -71,7 +70,7 @@ class type_checked():
 
         Returns
         -------
-        wrapper : callable
+        decorated : callable
             Decorated function.
         """
         signature = inspect.signature(func)
@@ -89,7 +88,7 @@ class type_checked():
                                                parameter.annotation))
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def decorated(*args, **kwargs):
             bound_arguments = signature.bind(*args, **kwargs)
             all_args = bound_arguments.arguments
 
@@ -112,7 +111,7 @@ class type_checked():
                     raise TypeError('expected {}, returned {}'.format(annotation, type(result)))
             return result
 
-        return wrapper
+        return decorated
 
     @staticmethod
     def __is_suitable_annotation(annotation):

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -29,6 +29,19 @@ class type_checked():
         Parameter.POSITIONAL_OR_KEYWORD
     )
 
+    def __new__(cls, *args, **kwargs):
+        self = super().__new__(cls)
+
+        if not args or isinstance(args[0], bool):
+            # Called as @type_checked(...)
+            return self
+        elif callable(args[0]):
+            # Called as @type_checked
+            msg = "type_checked must be called with brackets like this type_checked() and can only accept booleans."
+            raise SyntaxError(msg)
+        else:
+            raise TypeError("Illegal decorator argument: {}".format(args[0]))
+
     def __init__(self, check_arguments=True, check_defaults=True, check_return=True):
         """
         Parameters
@@ -95,7 +108,6 @@ class type_checked():
             return result
 
         return wrapper
-
 
     @staticmethod
     def __is_suitable_annotation(annotation):

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -37,8 +37,8 @@ class type_checked():
             return self
         elif callable(args[0]):
             # Called as @type_checked
-            msg = "type_checked must be called with brackets like this type_checked() and can only accept booleans."
-            raise SyntaxError(msg)
+            self.__init__()
+            return self.__call__(args[0])
         else:
             raise TypeError("Illegal decorator argument: {}".format(args[0]))
 

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -12,6 +12,7 @@ from inspect import Parameter
 
 
 class type_checked():
+
     """Decorator for dynamic type checking with annotations.
 
     + Each Parameter and the return value can be annotated with one expression of <class 'type'>.
@@ -46,6 +47,7 @@ class type_checked():
 
     def __init__(self, check_arguments=True, check_defaults=True, check_return=True):
         """
+
         Parameters
         ----------
         check_arguments : bool
@@ -61,6 +63,7 @@ class type_checked():
 
     def __call__(self, func):
         """
+
         Parameters
         ----------
         func : callable
@@ -118,6 +121,6 @@ class type_checked():
         This is supposed to prevent other python expressions in annotations
         from crashing this decorator.
         """
-        # Used for testing Parameter and Signature annotations. Might fail in the future due to Parameter.empty !=
-        # Signature.empty.
+        # Used for testing Parameter and Signature annotations. Might fail in the future due to
+        # Parameter.empty != Signature.empty.
         return annotation is not Parameter.empty and isinstance(annotation, type)

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -75,6 +75,7 @@ class type_checked():
 
     def __init__(self, check_arguments=True, check_defaults=True, check_return=True):
         """Sets decorator arguments.
+
         Parameters
         ----------
         check_arguments : bool

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -11,25 +11,17 @@ from functools import wraps
 from inspect import Parameter
 
 
-def type_checked(func):
+class type_checked():
     """Decorator for dynamic type checking with annotations.
 
     + Each Parameter and the return value can be annotated with one expression of <class 'type'>.
     + Other expressions or missing annotations are ignored.
     + Default values are type checked once the decorator is used for the first time.
     + All other annotations are checked once per function call.
+    + Type checking of arguments, default values or the return value can be turned off separately.
     + Annotations for *args and **kwargs are ignored.
-
-    Parameters
-    ----------
-    func : callable
-        Function to be type checked.
-
-    Returns
-    -------
-    wrapper : callable
-        Decorated function.
     """
+
     # *args, **kwargs are ignored.
     ALLOWED_PARAMETER_KINDS = (
         Parameter.POSITIONAL_ONLY,
@@ -37,47 +29,79 @@ def type_checked(func):
         Parameter.POSITIONAL_OR_KEYWORD
     )
 
-    def is_suitable_annotation(annotation):
+    def __init__(self, check_arguments=True, check_defaults=True, check_return=True):
+        """
+        Parameters
+        ----------
+        check_arguments : bool
+            Decided wheter arguments should be checked at execution time.
+        check_defaults : bool
+            Decides whether default values should be checked at declaration.
+        check_return : bool
+            Decides whether the return value should be checked at execution time.
+        """
+        self.check_arguments = check_arguments
+        self.check_defaults = check_defaults
+        self.check_return = check_return
+
+    def __call__(self, func):
+        """
+        Parameters
+        ----------
+        func : callable
+            Function to be type checked.
+
+        Returns
+        -------
+        wrapper : callable
+            Decorated function.
+        """
+        signature = inspect.signature(func)
+        parameters = signature.parameters
+
+        # Check type of default values.
+        if self.check_defaults:
+            for parameter in parameters.values():
+                if (parameter.default is not Parameter.empty
+                    and parameter.default is not None
+                    and self.__is_suitable_annotation(parameter.annotation)
+                    and not isinstance(parameter.default, parameter.annotation)):
+                    msg = 'default argument {}={} is not instance of {}'
+                    raise TypeError(msg.format(parameter.name, parameter.default,
+                                               parameter.annotation))
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            bound_arguments = signature.bind(*args, **kwargs)
+            all_args = bound_arguments.arguments
+
+            # Check type of positional and keyword arguments.
+            if self.check_arguments:
+                for arg_name, value in all_args.items():
+                    parameter = parameters[arg_name]
+                    annotation = parameter.annotation
+                    if (parameter.kind in self.ALLOWED_PARAMETER_KINDS
+                        and self.__is_suitable_annotation(annotation)
+                        and not isinstance(value, annotation)):
+                        msg = 'argument {}={} is not instance of {}'
+                        raise TypeError(msg.format(arg_name, value, annotation))
+
+            # Check type of return value.
+            result = func(*args, **kwargs)
+            if self.check_return:
+                annotation = signature.return_annotation
+                if self.__is_suitable_annotation(annotation) and not isinstance(result, annotation):
+                    raise TypeError('expected {}, returned {}'.format(annotation, type(result)))
+            return result
+
+        return wrapper
+
+
+    @staticmethod
+    def __is_suitable_annotation(annotation):
         """Checks wether annotation is specified and is a type.
 
         This is supposed to prevent other python expressions in annotations
         from crashing this decorator.
         """
         return annotation is not Parameter.empty and isinstance(annotation, type)
-
-    signature = inspect.signature(func)
-    parameters = signature.parameters
-
-    # Check type of default values.
-    for parameter in parameters.values():
-        if (parameter.default is not Parameter.empty
-            and parameter.default is not None
-            and is_suitable_annotation(parameter.annotation)
-            and not isinstance(parameter.default, parameter.annotation)):
-            msg = 'default argument {}={} is not instance of {}'
-            raise TypeError(msg.format(parameter.name, parameter.default,
-                                       parameter.annotation))
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        bound_arguments = signature.bind(*args, **kwargs)
-        all_args = bound_arguments.arguments
-
-        # Check type of positional and keyword arguments.
-        for arg_name, value in all_args.items():
-            parameter = parameters[arg_name]
-            annotation = parameter.annotation
-            if (parameter.kind in ALLOWED_PARAMETER_KINDS
-                and is_suitable_annotation(annotation)
-                and not isinstance(value, annotation)):
-                msg = 'argument {}={} is not instance of {}'
-                raise TypeError(msg.format(arg_name, value, annotation))
-
-        # Check type of return value.
-        result = func(*args, **kwargs)
-        annotation = signature.return_annotation
-        if is_suitable_annotation(annotation) and not isinstance(result, annotation):
-            raise TypeError('expected {}, returned {}'.format(annotation, type(result)))
-        return result
-
-    return wrapper

--- a/uniphy/decorators.py
+++ b/uniphy/decorators.py
@@ -95,7 +95,7 @@ class type_checked():
                     parameter = parameters[arg_name]
                     annotation = parameter.annotation
                     if (parameter.kind in self.ALLOWED_PARAMETER_KINDS
-                        and self.__is_suitable_annotation(annotation)
+                        and self.__is_suitable_annotation(annotation)  # If failes might be due to Parameter.empty != Signature.empty
                         and not isinstance(value, annotation)):
 
                         msg = 'argument {}={} is not instance of {}'
@@ -118,4 +118,6 @@ class type_checked():
         This is supposed to prevent other python expressions in annotations
         from crashing this decorator.
         """
+        # Used for testing Parameter and Signature annotations. Might fail in the future due to Parameter.empty !=
+        # Signature.empty.
         return annotation is not Parameter.empty and isinstance(annotation, type)


### PR DESCRIPTION
# Introduce Arguments to the Type_Checked Decorator.
The decorator effectively becomes a decorator factory. The arguments can be used to turn on or off type-checking for:
* Arguments
* Default values
* Return value

Default is all on.
Only catch: The method used so far makes it impossible to use the decorator without brackets.

## Examples
This works
```python
@type_checked(check_arguments=True, check_defaults=False, check_return=False)
def foo():
  pass
```
This as well
```python
@type_checked()
def foo():
  pass
````
This gives an error.
```python
@type_checked
def foo():
  pass
````

## TODO:
- [x] Check whether this can be implemented with no brackets. -> yes it can.
- [x] Write tests.

## EDIT
The decorator can now be used both with or without brackets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phynix/uniphy/13)
<!-- Reviewable:end -->
